### PR TITLE
Fix: correct invalid GSC bucket location for async_form_parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Please note Colab and Jupyter notebooks are also work with these samples. Howeve
 
 ## Instructions
 
-1. Identify which form type or utility you would like to run through a processor.
+1. Create a General Form Parser on the GCP Console
 2. Create your processor using the [instructions][create_processor].
 3. Copy your processor id.
 ![processorId](resources/screenshots/FormParserID.png)

--- a/general/async_form_parser.ipynb
+++ b/general/async_form_parser.ipynb
@@ -56,7 +56,7 @@
     "PROCESSOR_ID = \"PROCESSOR_ID\"  # Create processor in Cloud Console\n",
     "\n",
     "GCS_INPUT_BUCKET = 'cloud-samples-data'\n",
-    "GCS_INPUT_PREFIX = 'documentai/async_forms/'\n",
+    "GCS_INPUT_PREFIX = 'documentai/codelabs/form-parser/'\n",
     "GCS_OUTPUT_URI = 'YOUR-OUTPUT-BUCKET'\n",
     "GCS_OUTPUT_URI_PREFIX = 'TEST'\n",
     "TIMEOUT = 300"


### PR DESCRIPTION
This is to fix https://github.com/GoogleCloudPlatform/documentai-notebooks/issues/25 where an invalid GCS bucket is specified. 

I found an appropriate PDF file to be used for this notebook and redirected the notebook to point to that bucket.

I also updated the README to be clear that users need to create a General Form Parser